### PR TITLE
Use xyann for annotation if attribute available

### DIFF
--- a/Ska/Matplotlib/lineid_plot.py
+++ b/Ska/Matplotlib/lineid_plot.py
@@ -8,7 +8,7 @@ import numpy as np
 import matplotlib
 from matplotlib import pyplot as plt
 
-__version__ = "0.2"
+__version__ = "0.3_ska"
 __author__ = "Prasanth Nair"
 
 


### PR DESCRIPTION
This change supports the xyann/xyext API change in matplotlib 1.4.0

http://matplotlib.org/api/api_changes.html#changes-in-1-4-x

A conditional is used in this change so it is backward compatible.
