### PR TITLE
Avoid top-level import of pyplot for benefit of upstream packages

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -3,7 +3,6 @@
 
 import warnings
 import datetime
-from matplotlib import pyplot
 from matplotlib.dates import (YearLocator, MonthLocator, DayLocator,
                               HourLocator, MinuteLocator, SecondLocator,
                               DateFormatter, epoch2num)
@@ -132,6 +131,7 @@ def plot_cxctime(times, y, fmt='-b', fig=None, ax=None, yerr=None, xerr=None, tz
 
     :rtype: ticklocs, fig, ax = tick locations, figure, and axes object.
     """
+    from matplotlib import pyplot
 
     if fig is None:
         fig = pyplot.gcf()

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Provide useful utilities for matplotlib."""
 
-import warnings
-import datetime
 from matplotlib.dates import (YearLocator, MonthLocator, DayLocator,
                               HourLocator, MinuteLocator, SecondLocator,
                               DateFormatter, epoch2num)
@@ -55,7 +53,7 @@ def set_time_ticks(plt, ticklocs=None):
     Pick nice values to show time ticks in a date plot.
 
     Example::
-    
+
       x = cxctime2plotdate(np.linspace(0, 3e7, 20))
       y = np.random.normal(size=len(x))
 
@@ -96,7 +94,7 @@ def remake_ticks(ax):
     """
     ticklocs = set_time_ticks(ax)
     ax.figure.canvas.draw()
-    
+
 def plot_cxctime(times, y, fmt='-b', fig=None, ax=None, yerr=None, xerr=None, tz=None,
                  state_codes=None, interactive=True, **kwargs):
     """Make a date plot where the X-axis values are in CXC time.  If no ``fig``
@@ -122,7 +120,7 @@ def plot_cxctime(times, y, fmt='-b', fig=None, ax=None, yerr=None, xerr=None, tz
     :param y: y values
     :param fmt: plot format (default = '-b')
     :param fig: pyplot figure object (optional)
-    :param yerr: error on y values, may be [ scalar | N, Nx1, or 2xN array-like ] 
+    :param yerr: error on y values, may be [ scalar | N, Nx1, or 2xN array-like ]
     :param xerr: error on x values in units of DAYS (may be [ scalar | N, Nx1, or 2xN array-like ] )
     :param tz: timezone string
     :param state_codes: list of (raw_count, state_code) tuples
@@ -164,17 +162,17 @@ def cxctime2plotdate(times):
     """
     Convert input CXC time (sec) to the time base required for the matplotlib
     plot_date function (days since start of year 1).
-    
+
     :param times: iterable list of times
     :rtype: plot_date times
     """
-    
+
     # Find the plotdate of first time and use a relative offset from there
     t0 = Chandra.Time.DateTime(times[0]).unix
     plotdate0 = epoch2num(t0)
 
     return (np.asarray(times) - times[0]) / 86400. + plotdate0
-        
+
 
 def pointpair(x, y=None):
     """Interleave and then flatten two arrays ``x`` and ``y``.  This is
@@ -226,7 +224,7 @@ def hist_outline(dataIn, *args, **kwargs):
     stepSize = binsIn[1] - binsIn[0]
 
     bins = np.zeros(len(binsIn)*2 + 2, dtype=np.float)
-    data = np.zeros(len(binsIn)*2 + 2, dtype=np.float)    
+    data = np.zeros(len(binsIn)*2 + 2, dtype=np.float)
     for bb in range(len(binsIn)):
         bins[2*bb + 1] = binsIn[bb]
         bins[2*bb + 2] = binsIn[bb] + stepSize
@@ -238,7 +236,7 @@ def hist_outline(dataIn, *args, **kwargs):
     bins[-1] = bins[-2]
     data[0] = 0
     data[-1] = 0
-    
+
     return (bins, data)
 
 

--- a/Ska/Matplotlib/lineid_plot.py
+++ b/Ska/Matplotlib/lineid_plot.py
@@ -7,7 +7,6 @@ from __future__ import division, print_function, absolute_import
 from distutils.version import LooseVersion
 import numpy as np
 import matplotlib
-from matplotlib import pyplot as plt
 from six.moves import zip
 
 __version__ = "0.3_ska"
@@ -223,6 +222,8 @@ def prepare_axes(wave, flux, fig=None, ax_lower=(0.1, 0.1),
                  ax_dim=(0.85, 0.65)):
     """Create fig and axes if needed and layout axes in fig."""
     # Axes location in figure.
+    from matplotlib import pyplot as plt
+
     if not fig:
         fig = plt.figure()
     ax = fig.add_axes([ax_lower[0], ax_lower[1], ax_dim[0], ax_dim[1]])
@@ -441,6 +442,7 @@ def plot_line_ids(wave, flux, line_wave, line_label1, label1_size=None,
     return fig, ax
 
 if __name__ == "__main__":
+    from matplotlib import pyplot as plt
     wave = 1240 + np.arange(300) * 0.1
     flux = np.random.normal(size=300)
     line_wave = [1242.80, 1260.42, 1264.74, 1265.00, 1265.2, 1265.3, 1265.35]


### PR DESCRIPTION
This is a possible fix for problems with ORviewer (vis a vis the xija import) where we want to avoid a pyplot import for tools that may just be using a non-interactive backend.

This package has no tests, so testing is not so trivial.

## Functional testing

### Matplotlib backend not set on import

```
In [1]: import matplotlib

In [2]: matplotlib.get_backend()
Out[2]: 'MacOSX'

In [3]: from Ska.Matplotlib import *

In [4]: matplotlib.get_backend()  # Default backend not changed
Out[4]: 'MacOSX'

In [5]: matplotlib.use('Agg')  # Can still set backend

In [6]: import matplotlib.pyplot

In [7]: matplotlib.use('MacOSX')  # After pyplot import cannot set backend
/Users/aldcroft/miniconda3/envs/ska3/lib/python3.6/site-packages/matplotlib/__init__.py:1405: UserWarning: 
This call to matplotlib.use() has no effect because the backend has already
been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
or matplotlib.backends is imported for the first time.

  warnings.warn(_use_error_msg)
```
### Plot functions work
```
In [9]: plot_cxctime([0, 100], [0, 100])
Out[9]: 
(((matplotlib.dates.SecondLocator,
   {'bysecond': (0, 15, 30, 45)},
   '%H:%M:%S',
   matplotlib.dates.SecondLocator,
   {'bysecond': [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]}),),
 <matplotlib.figure.Figure at 0x7fb0189b4d68>,
 <matplotlib.axes._subplots.AxesSubplot at 0x7fb068d05c88>)

In [10]: matplotlib.pyplot.savefig('junk.png')

In [11]: from Ska.Matplotlib.lineid_plot import *

In [12]: plot_line_ids?

In [13]: plot_line_ids([0, 10], [0, 10], [5], ['label'])
Out[13]: 
(<matplotlib.figure.Figure at 0x7fb0191212b0>,
 <matplotlib.axes._axes.Axes at 0x7fb0191210f0>)

In [14]: matplotlib.pyplot.savefig('lines.png')

In [15]: !open lines.png

In [16]: !open junk.png
```
![image](https://user-images.githubusercontent.com/348089/81738458-be17e200-9467-11ea-90ef-662d7cde98d1.png)

![image](https://user-images.githubusercontent.com/348089/81738479-c5d78680-9467-11ea-8bf7-2e249ac2cf68.png)

```
