### PR TITLE
Handle shaped and zero-length input data in cxctime2plotdate

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -177,10 +177,19 @@ def cxctime2plotdate(times):
         if times.dtype.kind != 'f':
             times = CxoTime(times).secs
 
+    shape = times.shape
+
+    # Zero-length input gives empty output
+    if shape == (0,):
+        return np.array([], dtype=np.float64)
+
     # Find the plotdate of first time and use a relative offset from there
+    times = times.ravel()
     t0 = CxoTime(times[0]).unix
     plotdate0 = epoch2num(t0)
-    return (times - times[0]) / 86400. + plotdate0
+    out = (times - times[0]) / 86400. + plotdate0
+
+    return out.reshape(shape)
 
 
 def pointpair(x, y=None):

--- a/test.py
+++ b/test.py
@@ -67,3 +67,18 @@ def test_cxctime2plotdate():
 
     plt.legend(fontsize='small')
     plt.savefig('test-time-inputs.png')
+
+
+def test_cxctime2plotdate_shapes():
+    pd_ref = cxctime2plotdate([1, 2, 3, 4])
+
+    out = cxctime2plotdate([])
+    assert out.shape == (0,)
+
+    out = cxctime2plotdate(1)
+    assert out.shape == ()
+    assert out == pd_ref[0]
+
+    out = cxctime2plotdate([[1, 2], [3, 4]])
+    assert out.shape == (2, 2)
+    assert np.all(out.ravel() == pd_ref)


### PR DESCRIPTION
## Description

`cxctime2plotdate` previously only accepted 1-d data, and crashed for a zero-length input. This fixes that.

## Testing

- [x] Passes unit tests on MacOS (with new tests)
- [n/a] Functional testing
