### PR TITLE
remove use of deprecated np.float

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -185,8 +185,7 @@ def cxctime2plotdate(times):
 
     # Find the plotdate of first time and use a relative offset from there
     times = times.ravel()
-    t0 = CxoTime(times[0]).unix
-    plotdate0 = date2num(t0 * 1e6)  # Float arg to date2num is in microsecs
+    plotdate0 = date2num(CxoTime(times[0]).datetime)
     out = (times - times[0]) / 86400. + plotdate0
 
     return out.reshape(shape)

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -3,7 +3,7 @@
 
 from matplotlib.dates import (YearLocator, MonthLocator, DayLocator,
                               HourLocator, MinuteLocator, SecondLocator,
-                              DateFormatter, epoch2num)
+                              DateFormatter, date2num)
 from matplotlib.ticker import FixedLocator, FixedFormatter
 from Chandra.Time import DateTime
 from cxotime import CxoTime
@@ -186,7 +186,7 @@ def cxctime2plotdate(times):
     # Find the plotdate of first time and use a relative offset from there
     times = times.ravel()
     t0 = CxoTime(times[0]).unix
-    plotdate0 = epoch2num(t0)
+    plotdate0 = date2num(t0) * 1e6
     out = (times - times[0]) / 86400. + plotdate0
 
     return out.reshape(shape)

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -239,8 +239,8 @@ def hist_outline(dataIn, *args, **kwargs):
 
     stepSize = binsIn[1] - binsIn[0]
 
-    bins = np.zeros(len(binsIn)*2 + 2, dtype=np.float64)
-    data = np.zeros(len(binsIn)*2 + 2, dtype=np.float64)
+    bins = np.zeros(len(binsIn)*2 + 2, dtype=float)
+    data = np.zeros(len(binsIn)*2 + 2, dtype=float)
     for bb in range(len(binsIn)):
         bins[2*bb + 1] = binsIn[bb]
         bins[2*bb + 2] = binsIn[bb] + stepSize

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -239,8 +239,8 @@ def hist_outline(dataIn, *args, **kwargs):
 
     stepSize = binsIn[1] - binsIn[0]
 
-    bins = np.zeros(len(binsIn)*2 + 2, dtype=np.float)
-    data = np.zeros(len(binsIn)*2 + 2, dtype=np.float)
+    bins = np.zeros(len(binsIn)*2 + 2, dtype=np.float64)
+    data = np.zeros(len(binsIn)*2 + 2, dtype=np.float64)
     for bb in range(len(binsIn)):
         bins[2*bb + 1] = binsIn[bb]
         bins[2*bb + 2] = binsIn[bb] + stepSize

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -186,7 +186,7 @@ def cxctime2plotdate(times):
     # Find the plotdate of first time and use a relative offset from there
     times = times.ravel()
     t0 = CxoTime(times[0]).unix
-    plotdate0 = date2num(t0) * 1e6
+    plotdate0 = date2num(t0 * 1e6)  # Float arg to date2num is in microsecs
     out = (times - times[0]) / 86400. + plotdate0
 
     return out.reshape(shape)


### PR DESCRIPTION
## Description

This PR makes tiny changes to remove uses of a few deprecated dtypes (https://github.com/sot/skare3/issues/753). This module has no tests, but the change is simple enough.

It also replaces `mpl.epoch2num` by `mpl.date2num`. `mpl.epoch2num` is deprecated in 3.3.0 and un-deprecated in 3.3.1.

## Testing

- [n/a] Passes unit tests (not available)
- [x] Functional testing:
```
import sys
sys.path.insert(0, '/Users/javierg/SAO/git/Ska.Matplotlib')

from Ska.Matplotlib import plot_cxctime
from cxotime import CxoTime

x = CxoTime(['2000:200:10:00:54.000', '2000:255:22:05:13.000',
        '2000:260:11:48:03.000', '2000:259:14:18:04.000',
        '2000:261:20:02:12.000', '2000:263:14:31:14.000',
        '2000:116:04:16:24.000', '2000:170:13:42:58.000',
        '2000:282:09:05:04.000', '2000:104:09:57:52.000'])
y = np.array([-0.14152936, -0.08862624,  0.1887119 , -0.04996345, -0.08275661,
         0.00739793, -1.54209896, -0.01827701,  0.02285568, -0.12560554])
plot_cxctime(x, y, '.', label='dy')
```
