### PR TITLE
Prevent matplotlib warning

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -138,11 +138,6 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
     if ax is None:
         ax = fig.gca()
 
-    ls = '' if 'linestyle' in kwargs or 'ls' in kwargs else '-'
-    col = '' if 'color' in kwargs else 'b'
-    default_fmt = f'{ls}{col}'
-    if fmt is None and default_fmt:
-        fmt = default_fmt
     if fmt is not None:
         kwargs.update({'fmt': fmt})
 

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -119,7 +119,7 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
 
     :param times: CXC time values for x-axis (DateTime compatible format, CxoTime)
     :param y: y values
-    :param fmt: plot format (default = '-b')
+    :param fmt: plot format (not used by default, matplotlib will use its default)
     :param fig: pyplot figure object (optional)
     :param yerr: error on y values, may be [ scalar | N, Nx1, or 2xN array-like ]
     :param xerr: error on x values in units of DAYS (may be [ scalar | N, Nx1, or 2xN array-like ] )

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -96,7 +96,7 @@ def remake_ticks(ax):
     ticklocs = set_time_ticks(ax)
     ax.figure.canvas.draw()
 
-def plot_cxctime(times, y, fmt='-b', fig=None, ax=None, yerr=None, xerr=None, tz=None,
+def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz=None,
                  state_codes=None, interactive=True, **kwargs):
     """Make a date plot where the X-axis values are in a CXC time compatible format.  If no ``fig``
     value is supplied then the current figure will be used (and created
@@ -137,6 +137,12 @@ def plot_cxctime(times, y, fmt='-b', fig=None, ax=None, yerr=None, xerr=None, tz
 
     if ax is None:
         ax = fig.gca()
+
+    ls = '-' if 'linestyle' not in kwargs else ''
+    col = 'b' if 'color' not in kwargs else''
+    default_fmt = f'{ls}{col}'
+    if fmt is None and default_fmt:
+        fmt = default_fmt
 
     if yerr is not None or xerr is not None:
         ax.errorbar(cxctime2plotdate(times), y, yerr=yerr, xerr=xerr, fmt=fmt, **kwargs)

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -138,17 +138,20 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
     if ax is None:
         ax = fig.gca()
 
-    ls = '-' if 'linestyle' not in kwargs else ''
-    col = 'b' if 'color' not in kwargs else''
+    ls = '' if 'linestyle' in kwargs or 'ls' in kwargs else '-'
+    col = '' if 'color' in kwargs else 'b'
     default_fmt = f'{ls}{col}'
     if fmt is None and default_fmt:
         fmt = default_fmt
+    if fmt is not None:
+        kwargs.update({'fmt': fmt})
 
     if yerr is not None or xerr is not None:
-        ax.errorbar(cxctime2plotdate(times), y, yerr=yerr, xerr=xerr, fmt=fmt, **kwargs)
+        ax.errorbar(cxctime2plotdate(times), y, yerr=yerr, xerr=xerr, **kwargs)
         ax.xaxis_date(tz)
     else:
-        ax.plot_date(cxctime2plotdate(times), y, fmt=fmt, **kwargs)
+        ax.plot_date(cxctime2plotdate(times), y, **kwargs)
+
     ticklocs = set_time_ticks(ax)
     fig.autofmt_xdate()
 


### PR DESCRIPTION
## Description

This PR prevents the warning that appeared in sot/skare3/pull/755:
```
linestyle is redundantly defined by the 'linestyle' keyword argument and the fmt string.
```
which occurs because both fmt and linestyle/color are given.

There might be a better way to handle these potentially conflicting arguments.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #