### PR TITLE
Separate fmt handling for errorbar/plot_date

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -144,6 +144,9 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
         ax.errorbar(cxctime2plotdate(times), y, yerr=yerr, xerr=xerr, **kwargs)
         ax.xaxis_date(tz)
     else:
+
+        # If fmt is None override with fmt='' for plot_date(). The plot_date()
+        # default of 'o' is undesireable.
         if fmt is None:
             fmt = ''
         ax.plot_date(cxctime2plotdate(times), y, fmt=fmt, **kwargs)

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -119,7 +119,7 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
 
     :param times: CXC time values for x-axis (DateTime compatible format, CxoTime)
     :param y: y values
-    :param fmt: plot format (not used by default, matplotlib will use its default)
+    :param fmt: plot format (default None passes fmt='' to plot_date() and nothing to errorbar())
     :param fig: pyplot figure object (optional)
     :param yerr: error on y values, may be [ scalar | N, Nx1, or 2xN array-like ]
     :param xerr: error on x values in units of DAYS (may be [ scalar | N, Nx1, or 2xN array-like ] )

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -138,14 +138,15 @@ def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz
     if ax is None:
         ax = fig.gca()
 
-    if fmt is not None:
-        kwargs.update({'fmt': fmt})
-
     if yerr is not None or xerr is not None:
+        if fmt is not None:
+            kwargs.update({'fmt': fmt})
         ax.errorbar(cxctime2plotdate(times), y, yerr=yerr, xerr=xerr, **kwargs)
         ax.xaxis_date(tz)
     else:
-        ax.plot_date(cxctime2plotdate(times), y, **kwargs)
+        if fmt is None:
+            fmt = ''
+        ax.plot_date(cxctime2plotdate(times), y, fmt=fmt, **kwargs)
 
     ticklocs = set_time_ticks(ax)
     fig.autofmt_xdate()


### PR DESCRIPTION
## Description

Handle 'fmt' separately for errorbar() and plot_date() as part of plot_cxctime.

plot_date() has an annoying fmt='o' default that we don't want as the new implicit default.


## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

For functional testing, I ran a set of plot_cxctime commands from head ska3-flight and a ska3-next with this PR.

- flight https://icxc.cfa.harvard.edu/aspect/test_review_outputs/ska.matplotlib-pr23/plot_cxctime-plots-flight.html

- test https://icxc.cfa.harvard.edu/aspect/test_review_outputs/ska.matplotlib-pr23/plot_cxctime-plots-test.html

The plots and warnings look all as-expected between the two versions, except that flight seems to display a bug that `color` was previously ignored for errorbar plots.  This behaves correctly in the PR.

Fixes #22 