### PR TITLE
Use draw_idle instead of draw in remake_ticks

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -94,7 +94,7 @@ def remake_ticks(ax):
     is pressed then set the date ticks to the maximum possible range.
     """
     ticklocs = set_time_ticks(ax)
-    ax.figure.canvas.draw()
+    ax.figure.canvas.draw_idle()
 
 def plot_cxctime(times, y, fmt=None, fig=None, ax=None, yerr=None, xerr=None, tz=None,
                  state_codes=None, interactive=True, **kwargs):


### PR DESCRIPTION
## Description

``xija_gui_fit`` is prone to crashing, often without error messages, or only cryptic error messages such as this one:

```pytraceback
(ska) acis-110: xija_gui_fit ./dpa_spec_PROD.json --days 365 --stop 2022:105:00:00:00.00 &
Fetching msid: 1dpamzt over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
info:numexpr.utils:NumExpr defaulting to 4 threads.
Fetching msid: sim_z over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
Fetching msid: pitch over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
Fetching msid: roll over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
Fetching msid: aoeclips over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
Getting kadi commanded states over 2021:105:00:04:30.816 to 2022:104:23:51:42.816
Fetching msid: dp_dpa_power over 2021:104:23:37:10.816 to 2022:105:00:19:02.816
Adding plot  1dpamzt data__time
Adding plot  1dpamzt resid__time
Traceback (most recent call last):
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 3031, in _wait_cursor_for_draw_cm
    yield
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backends/backend_agg.py", line 439, in draw
    super().draw()
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backends/backend_qt.py", line 424, in draw
    self.update()
RuntimeError: wrapped C/C++ object of type MplCanvas has been deleted

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/cbook/__init__.py", line 287, in process
    func(*args, **kwargs)
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/Ska/Matplotlib/core.py", line 97, in remake_ticks
    ax.figure.canvas.draw()
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backends/backend_agg.py", line 439, in draw
    super().draw()
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 3033, in _wait_cursor_for_draw_cm
    self.canvas.set_cursor(self._lastCursor)
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backends/backend_qt.py", line 259, in set_cursor
    self.setCursor(_api.check_getitem(cursord, cursor=cursor))
RuntimeError: wrapped C/C++ object of type MplCanvas has been deleted
Traceback (most recent call last):
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/cbook/__init__.py", line 287, in process
    func(*args, **kwargs)
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 3077, in _zoom_pan_handler
    self.release_zoom(event)
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 3232, in release_zoom
    self.push_current()
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 3243, in push_current
    self.set_history_buttons()
  File "/data/acis/miniconda3/envs/ska/lib/python3.8/site-packages/matplotlib/backends/backend_qt.py", line 797, in set_history_buttons
    self._actions['back'].setEnabled(can_backward)
RuntimeError: wrapped C/C++ object of type QAction has been deleted
```

This can be resolved if the call to `ax.figure.canvas.draw` is changed to `ax.figure.canvas.draw_idle` in `remake_ticks`, which is what this PR does. 

From the [Matplotlib documentation](https://matplotlib.org/stable/users/explain/interactive_guide.html):

"In almost all cases, we recommend using [backend_bases.FigureCanvasBase.draw_idle](https://matplotlib.org/stable/api/backend_bases_api.html#matplotlib.backend_bases.FigureCanvasBase.draw_idle) over [backend_bases.FigureCanvasBase.draw](https://matplotlib.org/stable/api/backend_bases_api.html#matplotlib.backend_bases.FigureCanvasBase.draw). draw forces a rendering of the figure whereas draw_idle schedules a rendering the next time the GUI window is going to re-paint the screen."

## Testing
* Changing this line fixes crashes in ``xija_gui_fit``.
* I checked that the `iplot` functionality in `cheta` works correctly with this change. 
