### PR TITLE
Add function set_min_axis_range()

### DIFF
--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -273,6 +273,7 @@ def set_min_axis_range(ax, min_range, axis='y'):
     get_lim = getattr(ax, f'get_{axis}lim')
 
     lim0, lim1 = get_lim()
-    if lim1 - lim0 < min_range:
+    if abs(lim1 - lim0) < min_range:
         lim_mean = (lim0 + lim1) / 2
-        set_lim(lim_mean - min_range / 2, lim_mean + min_range / 2)
+        sign = 1 if lim1 > lim0 else -1
+        set_lim(lim_mean - sign * min_range / 2, lim_mean + sign * min_range / 2)

--- a/Ska/Matplotlib/core.py
+++ b/Ska/Matplotlib/core.py
@@ -259,3 +259,20 @@ def hist_outline(dataIn, *args, **kwargs):
     return (bins, data)
 
 
+def set_min_axis_range(ax, min_range, axis='y'):
+    """
+    Set the minimum range of the y- or x-axis limits of a matplotlib Axes object.
+
+    This is used to prevent the axis limits from being set to a very small range.
+
+    :param ax: matplotlib Axes object
+    :param min_range: minimum range of the axis
+    :param axis: axis to set (default 'y', also allowed 'x')
+    """
+    set_lim = getattr(ax, f'set_{axis}lim')
+    get_lim = getattr(ax, f'get_{axis}lim')
+
+    lim0, lim1 = get_lim()
+    if lim1 - lim0 < min_range:
+        lim_mean = (lim0 + lim1) / 2
+        set_lim(lim_mean - min_range / 2, lim_mean + min_range / 2)


### PR DESCRIPTION
## Description

Add a function to set the minimum range of the y- or x-axis limits of a matplotlib Axes object.  This is used to prevent the axis limits from being set to a very small range.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
>>> %matplotlib
Using matplotlib backend: MacOSX
>>> from Ska.Matplotlib import set_min_axis_range
>>> import matplotlib.pyplot as plt
>>> fig, ax = plt.subplots()
>>> ax.plot([0, 1, 2], [0.0, 0.01, -0.02])
>>> set_min_axis_range(ax, 1.0)
>>> set_min_axis_range(ax, 5.0, axis='x')
```
<img width="566" alt="image" src="https://user-images.githubusercontent.com/348089/191604699-6810608e-7845-4be8-9ff9-a34f5b781c7a.png">

```
>>> fig, ax = plt.subplots()
>>> ax.plot([0, 1, 2], [0.0, 0.01, -0.02])
[<matplotlib.lines.Line2D object at 0x7fc8407ebbe0>]
>>> ax.set_ylim(0.1, -0.1)
(0.1, -0.1)
>>> set_min_axis_range(ax, 1.0)
```
<img width="531" alt="image" src="https://user-images.githubusercontent.com/348089/191618908-cd353d0e-89a7-4bf9-b22f-52e3fc7b952b.png">
